### PR TITLE
Fix Carthage deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains releases for the Twilio Programmable Voice for iOS SDK.
 
 We support integration using Carthage binary frameworks. You can add Programmable Voice for iOS by adding the following line to your Cartfile:
 ```
-github "twilio/twilio-voice-ios"
+binary "https://raw.githubusercontent.com/twilio/twilio-voice-ios/Releases/TwilioVoice.json"
 ```
 
 Then run `carthage bootstrap` (or `carthage update` if you are updating your SDKs)

--- a/TwilioVoice.json
+++ b/TwilioVoice.json
@@ -1,0 +1,12 @@
+{
+    "3.1.1": "https://github.com/twilio/twilio-voice-ios/releases/download/3.1.1/TwilioVoice.framework.zip",
+    "3.1.0": "https://github.com/twilio/twilio-voice-ios/releases/download/3.1.0/TwilioVoice.framework.zip",
+    "3.0.0": "https://github.com/twilio/twilio-voice-ios/releases/download/3.0.0/TwilioVoice.framework.zip",
+    "2.0.7": "https://github.com/twilio/twilio-voice-ios/releases/download/2.0.7/TwilioVoice.framework.zip",
+    "2.0.6": "https://github.com/twilio/twilio-voice-ios/releases/download/2.0.6/TwilioVoice.framework.zip",
+    "2.0.5": "https://github.com/twilio/twilio-voice-ios/releases/download/2.0.5/TwilioVoice.framework.zip",
+    "2.0.4": "https://github.com/twilio/twilio-voice-ios/releases/download/2.0.4/TwilioVoice.framework.zip",
+    "2.0.3": "https://github.com/twilio/twilio-voice-ios/releases/download/2.0.3/TwilioVoice.framework.zip",
+    "2.0.2": "https://github.com/twilio/twilio-voice-ios/releases/download/2.0.2/TwilioVoice.framework.zip",
+    "2.0.1": "https://github.com/twilio/twilio-voice-ios/releases/download/v2.0.1/TwilioVoice.framework.zip"
+}


### PR DESCRIPTION
Add TwilioVoice.json that indexes all releases
Update README.md with correct use of carthage

<!-- Describe your Pull Request -->
This binary only framework is currently distributed the wrong way using carthage
This pull request fixes this issue.
More details on distributing binary framework are available on Carthage's documentation:
- [binary-project-specification](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-project-specification)
- [binary-only-frameworks](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-only-frameworks)


I updated README.md with the right way of adding TwilioVoice framework with this line
```
binary "https://raw.githubusercontent.com/twilio/twilio-voice-ios/Releases/TwilioVoice.json"
```
This ressource location will be available once you accept the pull request.

If you want to test you can use the location from this pull request's branch that will download the latest version
```
binary "https://raw.githubusercontent.com/rkrim/twilio-voice-ios/fix_carthage_binary_deployment/TwilioVoice.json"
```
Developers will also be able to explicitly specify a version, from one listed in `TwilioVoice.json`
```
binary "resource_location" "version"
```
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
