### PR TITLE
Update iOS 13 migration guide with the error message when registering with invalid device token format

### DIFF
--- a/iOS-13-Migration-Guide.md
+++ b/iOS-13-Migration-Guide.md
@@ -45,7 +45,7 @@ If your App supports incoming calls, you **MUST** perform the following steps to
     }
     ```
 
-    Not updating your App's PushKit device token parsing logic will result in the following error message when being passed to the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
+    Not updating your App's PushKit device token parsing logic will result in the following error message when calling the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
 
     ```
     Error Domain=com.twilio.voice.error Code=31400 "Bad Request" UserInfo={NSLocalizedDescription=Bad Request, NSLocalizedFailureReason=20001 : Address of Apn Binding must be a nonempty string of even number of hexadecimal characters}
@@ -244,7 +244,7 @@ If your App supports incoming calls, you **MUST** perform the following steps to
     }
     ```
 
-    Not updating your App's PushKit device token parsing logic will result in the following error message when being passed to the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
+    Not updating your App's PushKit device token parsing logic will result in the following error message when calling the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
 
     ```
     Error Domain=com.twilio.voice.error Code=31301 "Http status: 400. Unexpected registration response." UserInfo={NSLocalizedDescription=Http status: 400. Unexpected registration response.}

--- a/iOS-13-Migration-Guide.md
+++ b/iOS-13-Migration-Guide.md
@@ -45,6 +45,12 @@ If your App supports incoming calls, you **MUST** perform the following steps to
     }
     ```
 
+    The device token decoded using the `description` method will result in the following error message when being passed to the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
+
+    ```
+    Error Domain=com.twilio.voice.error Code=31400 "Bad Request" UserInfo={NSLocalizedDescription=Bad Request, NSLocalizedFailureReason=20001 : Address of Apn Binding must be a nonempty string of even number of hexadecimal characters}
+    ```
+
 4. You must register via `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` when your App starts. This ensures that your app no longer receives “cancel” push notifications. A "call" push notification, when passed to `[TwilioVoice handleNotification:delegate:delegateQueue:]`, will return a `TVOCallInvite` object to you synchronously via the `[TVONotificationDelegate callInviteReceived:]` method when `[TwilioVoice handleNotification:delegate:delegateQueue:]` is called. A `TVOCancelledCallInvite` will be raised asynchronously via `[TVONotificationDelegate cancelledCallInviteReceived:error:]` if any of the following events occur:
     - The call is prematurely disconnected by the caller.
     - The callee does not accept or reject the call in approximately 30 seconds.
@@ -236,6 +242,12 @@ If your App supports incoming calls, you **MUST** perform the following steps to
                                                             ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
         ...
     }
+    ```
+
+    The device token decoded using the `description` method will result in the following error message when being passed to the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
+
+    ```
+    Error Domain=com.twilio.voice.error Code=31301 "Http status: 400. Unexpected registration response." UserInfo={NSLocalizedDescription=Http status: 400. Unexpected registration response.}
     ```
 
 4. You must register via `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` when your App starts. This ensures that your app no longer receives “cancel” push notifications. A "call" push notification, when passed to `[TwilioVoice handleNotification:delegate:]`, will return a `TVOCallInvite` object to you synchronously via the `[TVONotificationDelegate callInviteReceived:]` method when `[TwilioVoice handleNotification:delegate:]` is called. The SDK will invoke the `[TVONotificationDelegate callInviteReceived:]` method asynchronously with a `TVOCallInvite` object of state `TVOCallInviteStateCanceled` if any of the following events occur:

--- a/iOS-13-Migration-Guide.md
+++ b/iOS-13-Migration-Guide.md
@@ -45,7 +45,7 @@ If your App supports incoming calls, you **MUST** perform the following steps to
     }
     ```
 
-    The device token decoded using the `description` method will result in the following error message when being passed to the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
+    Not updating your App's PushKit device token parsing logic will result in the following error message when being passed to the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
 
     ```
     Error Domain=com.twilio.voice.error Code=31400 "Bad Request" UserInfo={NSLocalizedDescription=Bad Request, NSLocalizedFailureReason=20001 : Address of Apn Binding must be a nonempty string of even number of hexadecimal characters}
@@ -244,7 +244,7 @@ If your App supports incoming calls, you **MUST** perform the following steps to
     }
     ```
 
-    The device token decoded using the `description` method will result in the following error message when being passed to the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
+    Not updating your App's PushKit device token parsing logic will result in the following error message when being passed to the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` method:
 
     ```
     Error Domain=com.twilio.voice.error Code=31301 "Http status: 400. Unexpected registration response." UserInfo={NSLocalizedDescription=Http status: 400. Unexpected registration response.}


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

Describe the error message that the application will receive in the `TwilioVoice.register()` method callback if it is still using the `description` method, or any other way that might result in the invalid device token format.

Device token decoded by the `description` method will look like this if the app is built with Xcode 11 and running on iOS 13:
```
- (void)pushRegistry:(PKPushRegistry *)registry
didUpdatePushCredentials:(PKPushCredentials *)credentials
             forType:(NSString *)type {
    self.deviceToken = [credentials.token description];
    // device token will look like this: "{length = 32, bytes = 0xdeadbeef deadbeef deadbeef deadbeef ... deadbeef deadbeef }"
}
```

Applications using the Voice iOS SDK 3.x/4.x will receive error message passing the device token above to the `TwilioVoice.register()` method:
```
Error Domain=com.twilio.voice.error Code=31400 "Bad Request" UserInfo={NSLocalizedDescription=Bad Request, NSLocalizedFailureReason=20001 : Address of Apn Binding must be a nonempty string of even number of hexadecimal characters}
```

Applications using the Voice iOS SDK 2.x will receive error message:
```
Error Domain=com.twilio.voice.error Code=31301 "Http status: 400. Unexpected registration response." UserInfo={NSLocalizedDescription=Http status: 400. Unexpected registration response.}
```