### PR TITLE
Voice iOS 6.0.0 Release

### DIFF
--- a/twilio-voice-ios.json
+++ b/twilio-voice-ios.json
@@ -27,5 +27,6 @@
   "5.4.0": "https://github.com/twilio/twilio-voice-ios/releases/download/5.4.0/TwilioVoice.framework.zip",
   "5.4.1": "https://github.com/twilio/twilio-voice-ios/releases/download/5.4.1/TwilioVoice.framework.zip",
   "5.5.0": "https://github.com/twilio/twilio-voice-ios/releases/download/5.5.0/TwilioVoice.framework.zip",
-  "5.5.1": "https://github.com/twilio/twilio-voice-ios/releases/download/5.5.1/TwilioVoice.framework.zip"
+  "5.5.1": "https://github.com/twilio/twilio-voice-ios/releases/download/5.5.1/TwilioVoice.framework.zip",
+  "6.0.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.0/TwilioVoice.framework.zip"
 }


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

API Change

- The Voice SDK has been updated for better Swift interoperability.
  - The `TVO` prefix has been removed from all Twilio Voice types
  - Many of the delegate function declarations have been revamped for better clarity of their intent
  - Some of the class method declarations have been revamped for better clarity of their intent

- This release has improved API for CallKit integration. In order to use CallKit with SDK, you must set `ConnectOptions.uuid` or `AcceptOptions.uuid` while making or answering a Call. When `ConnectOptions.uuid` or `AcceptOptions.uuid` is set, it is your responsibility to enable and disable the audio device. You should enable the audio device in `[CXProviderDelegate provider:didActivateAudioSession:]`, and disable the audio device in `[CXProviderDelegate provider:didDeactivateAudioSession:]`.

```swift
    func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
        audioDevice.isEnabled = true
    }

    func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
        audioDevice.isEnabled = false
    }
    
    func providerDidReset(_ provider: CXProvider) {
        audioDevice.isEnabled = false
    }
```

If you are not using CallKit in your app, you must not set `ConnectOptions.uuid` or `AcceptOptions.uuid` while making or answering a call. The Voice SDK will enable the audio device for you when the `uuid` is `nil`. 

- The `uuid` property of `TVOCall` is now optional.

- This release changes the underlying behavior of `[TVOCallDelegate callDidConnect:]` such that it is raised when both ICE connection state is connected and DTLS negotiation has completed. Previously `[TVOCallDelegate callDidConnect:]` was raised when the DTLS negotiation had completed.
- In this release, `[TVOCallDelegate callDidConnect:]` is raised when both the ICE connection state is connected and DTLS negotiation has completed. There is no change in behavior however the SDK can detect DTLS failures and raise `kTVOMediaDtlsTransportFailedErrorCode` if they occur.
- Defined new error code

| Error Codes | ErrorCode  | Error Message |
| ------------| -----------| ------------- |
| 53407 | TVOMediaDtlsTransportFailedErrorCode | Media connection failed due to DTLS handshake failure |

- PeerConnection state is now reported to Insights

| Event Group | Level | Event Name | Description |
|-------------|-------|------------|-------------|
| pc-connection-state| DEBUG | new | Raised when peer connection state is new |
| pc-connection-state| DEBUG | connecting | Raised when peer connection state is connecting |
| pc-connection-state| DEBUG | connected | Raised when peer connection state is connected |
| pc-connection-state| DEBUG | disconnected | Raised when peer connection state is disconnected |
| pc-connection-state| ERROR | failed | Raised when peer connection state is failed |
| pc-connection-state| DEBUG | closed | Raised when peer connection state is closed |

- Removed the deprecated property `TwilioVoice.region`. Use `TwilioVoice.edge` to control the connectivity with Twilio.

- The `[TwilioVoice registerWithAccessToken:deviceTokenData:completion:]` and the `[TwilioVoice unregisterWithAccessToken:deviceTokenData:completion:]` have been renamed to replace the `[TwilioVoice registerWithAccessToken:deviceToken:completion:]` and the `[TwilioVoice unregisterWithAccessToken:deviceToken:completion:]` methods and now take the `NSData` type device token as parameter.

Enhancements

- This release is based on Chromium WebRTC 83.
- TwilioVoice.framework is now built with Xcode 11.4.1
- A new Insights event `selected-ice-candidate-pair` is reported with the active local ICE candidate and remote ICE candidate.

| Event Group | Level | Event Name | Description |
|-------------|-------|------------|-------------|
| ice-candidate | DEBUG | selected-ice-candidate-pair | Raised when the active local and remote ICE candidates of the peer connection are determined |

- `mos` calculation algorithm has been updated to make it monotonically decreasing with increasing `jitter` and `packets-lost-fraction` values over a range of `rtt` values. The final mos should always be in the range [1.0, 4.6].

- Added a security patch to prevent host candidate DNS attacks. See [Issue 11597](https://bugs.chromium.org/p/webrtc/issues/detail?id=11597).

Bug Fixes

- Fixed a crash when processing of empty stats reports or stats reports without remote audio tracks.