### PR TITLE
Voice iOS 6.0.2

### DIFF
--- a/twilio-voice-ios.json
+++ b/twilio-voice-ios.json
@@ -29,5 +29,6 @@
   "5.5.0": "https://github.com/twilio/twilio-voice-ios/releases/download/5.5.0/TwilioVoice.framework.zip",
   "5.5.1": "https://github.com/twilio/twilio-voice-ios/releases/download/5.5.1/TwilioVoice.framework.zip",
   "6.0.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.0/TwilioVoice.framework.zip",
-  "6.0.1": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.1/TwilioVoice.framework.zip"
+  "6.0.1": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.1/TwilioVoice.framework.zip",
+  "6.0.2": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.2/TwilioVoice.framework.zip"
 }


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

Bug Fixes

- Fixed Swift compile time error for `AudioDeviceWorkerBlock`.

### Size Impact for 6.0.2

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 3.1 MB | 6.8 MB
arm64 | 3.1 MB | 6.8 MB
