### PR TITLE
Add artifact link for Voice iOS 6.1.0 release

### DIFF
--- a/twilio-voice-ios.json
+++ b/twilio-voice-ios.json
@@ -30,5 +30,6 @@
   "5.5.1": "https://github.com/twilio/twilio-voice-ios/releases/download/5.5.1/TwilioVoice.framework.zip",
   "6.0.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.0/TwilioVoice.framework.zip",
   "6.0.1": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.1/TwilioVoice.framework.zip",
-  "6.0.2": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.2/TwilioVoice.framework.zip"
+  "6.0.2": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.2/TwilioVoice.framework.zip",
+  "6.1.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.1.0/TwilioVoice.framework.zip"
 }


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

Enhancements

- Private IP addresses are masked in Release mode for the SDK logs and the `ice-candidate` Insights event payload.
- Private IP addresses will not be masked in `Debug` mode. The `selected-ice-candidate-pair` event will contain private IP address of the local active ICE candidate for debugging purpose in both Release and Debug modes.

Bug Fixes

- Fixed a bug where caller might not receive the `call:didDisconnectWithError:` callback when the callee hangs up.
- Fixed a bug where callee was not receiving the `cancelledCallInviteReceived:error:` callback when signaling connection error happens.
- The Voice SDK had the same `TwilioVoice` framework name and the class name. This was causing Swift compile time errors when an app tries to access a TwilioVoice framework's class using the module name, e.g. `TwilioVoice.ConnectOptions`. Fixed this issues by renaming the `TwilioVoice` class name to `TwilioVoiceSDK`. [#420](https://github.com/twilio/voice-quickstart-ios/issues/420)