### PR TITLE
Add XCFramework releases to the Carthage spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,18 @@ do
 done
 
 ```
-    
+
+### Carthage
+
+We support integration using Carthage binary frameworks. You can add Programmable Voice for iOS by adding the following line to your Cartfile:
+```
+binary "https://raw.githubusercontent.com/twilio/twilio-voice-ios/Releases/twilio-voice-ios.json"
+```
+
+Then run `carthage bootstrap --use-xcframeworks` (or `carthage update --use-xcframeworks` if you are updating your SDKs)
+
+On your application targets’ _General_ settings tab, in the _Frameworks, Libraries, and Embedded Content_ section, drag and drop `TwilioVoice.xcframework` from the Carthage/Build folder on disk.
+ 
 ### CocoaPods
 
 It's easy to install the Voice framework if you manage your dependencies using [CocoaPods](http://cocoapods.org). Simply add the following to your `Podfile`:

--- a/twilio-voice-ios.json
+++ b/twilio-voice-ios.json
@@ -31,5 +31,9 @@
   "6.0.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.0/TwilioVoice.framework.zip",
   "6.0.1": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.1/TwilioVoice.framework.zip",
   "6.0.2": "https://github.com/twilio/twilio-voice-ios/releases/download/6.0.2/TwilioVoice.framework.zip",
-  "6.1.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.1.0/TwilioVoice.framework.zip"
+  "6.1.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.1.0/TwilioVoice.framework.zip",
+  "6.2.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.2.0/TwilioVoice.xcframework.zip",
+  "6.2.1": "https://github.com/twilio/twilio-voice-ios/releases/download/6.2.1/TwilioVoice.xcframework.zip",
+  "6.2.2": "https://github.com/twilio/twilio-voice-ios/releases/download/6.2.2/TwilioVoice.xcframework.zip",
+  "6.3.0": "https://github.com/twilio/twilio-voice-ios/releases/download/6.3.0/TwilioVoice.xcframework.zip"
 }


### PR DESCRIPTION
Carthage supports binary XCFrameworks [as of version 0.38.0](https://github.com/Carthage/Carthage/releases/tag/0.38.0), so it should be possible to add them to the binary spec JSON here.

Note that these releases won't be compatible for Carthage users who _haven't_ upgraded to 0.38.0. If you want to allow them to update, you'd need to create a framework-bundle version of the SDK and list in separately in the spec JSON (see "How to distribute XCFrameworks while retaining backwards compatibility" in the release notes above). Merely adding these won't break these users' ability to build, though, it will just prevent them from being able to `carthage update`.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
