### PR TITLE
Update for 6.13.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,13 +18,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "TwilioVoice",
-            url: "https://github.com/twilio/twilio-voice-ios/releases/download/6.13.6/TwilioVoice.xcframework.zip",
-            checksum: "4e04fa2698e33a47d15293f4437b1416fccad29c6e168695295c090c661d8acb"
+            url: "https://github.com/twilio/twilio-voice-ios/releases/download/6.13.7/TwilioVoice.xcframework.zip",
+            checksum: "bf96e9835bba054fd25731e63b516d469fa6768fba3832e4ad3867a23783727c"
         ),
         .binaryTarget(
             name: "TwilioVoice-static",
-            url: "https://github.com/twilio/twilio-voice-ios/releases/download/6.13.6/TwilioVoice-static.xcframework.zip",
-            checksum: "cf318d7590fcd4dfbe52be5fc34cbc9da3f8661e0d9a93714c51a379fee1dc8e"
+            url: "https://github.com/twilio/twilio-voice-ios/releases/download/6.13.7/TwilioVoice-static.xcframework.zip",
+            checksum: "f5961a676f54f9fe4c0f61bb81bae39f09cd2ae5bdda48d5a6b66a22b323765d"
         )
     ]
 )


### PR DESCRIPTION
Bump `Package.swift` binary target URLs and SPM checksums to 6.13.7.

- Dynamic: `bf96e9835bba054fd25731e63b516d469fa6768fba3832e4ad3867a23783727c`
- Static:  `f5961a676f54f9fe4c0f61bb81bae39f09cd2ae5bdda48d5a6b66a22b323765d`

Artifacts already published to Artifactory `releases/com/twilio/sdk/{TwilioVoice.xcframework,TwilioVoice-static.xcframework,twilio-voice-ios-internal}/6.13.7/`. GitHub Release + gh-pages docs + Cocoapods podspecs will land after this merges.

README podspec pin (`~> 6.13`) already matches — no README change needed.

This branch replaces the direct `Releases`-push that CI historically did, which is now blocked by the `pull_request` repo rule with no bypass actors.