### PR TITLE
Point TwilioVoice-static at correct binary

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TwilioVoice"]),
          .library(
             name: "TwilioVoice-static",
-            targets: ["TwilioVoice"]),
+            targets: ["TwilioVoice-static"]),
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
I noticed that both package products point to the same xcframework instead of the same that matches each name

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
